### PR TITLE
Context state documentation

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -1,6 +1,6 @@
 # State
 
-State is written using React Context with Hooks. The implementation can be found in `/src/context/report-context`.
+State is written using [React Context](https://reactjs.org/docs/context.html) with [Hooks](https://reactjs.org/docs/hooks-reference.html). The implementation can be found in `/src/context/report-context`.
 
 
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -41,48 +41,47 @@ The state also uses a reducer to manipulate state, which is also accessed throug
 
 To manipulate sightings, the reducer needs to be called through the dispatcher. The dispatcher requires a single object argument, with a required field of type, and other optional fields. The valid types and their corresponding data requirements are as follows:  
 
-* **Add**
+#### **Add**
 
-  * **Usage:**
+* **Usage:**
 
-    ```jsx
-    dispatch({ 
-        type:       'add', 
-        newSighting: { SightingObject }
-    });
-    ```
+  ```jsx
+  dispatch({ 
+      type:       'add', 
+      newSighting: { SightingObject }
+  });
+  ```
 
-  * **Summary:** Simply pushes the Sighting in `newSighting` to the `sightings` array.
-
-    
-
-* **remove**
-
-  * **Usage:**
-
-    ```jsx
-    dispatch({
-    	type:    'remove',
-        removeID: IDNum
-    });
-    ```
-
-  * **Summary:** Removes the sighting with the target `removeID` from the `sightings` array.
+* **Summary:** Simply pushes the Sighting in `newSighting` to the `sightings` array.
 
   
 
-* **update**
+#### **remove**
 
-  * **Usage:**
+* **Usage:**
 
-    ```jsx
-    dispatch({
-    	type:       'remove',
-        newSighting: { SightingObject }, // [REQUIRED] The updated object
-        updateID:    IDNum               // [REQUIRED] The id of the sighting to be updated
-    });
-    ```
+  ```jsx
+  dispatch({
+  	type:    'remove',
+      removeID: IDNum
+  });
+  ```
 
-  * **Summary:** Replaces the old sighting, targeted with `updateID` with the `newSighting`.
+* **Summary:** Removes the sighting with the target `removeID` from the `sightings` array.
 
-  
+
+
+#### **update**
+
+* **Usage:**
+
+  ```jsx
+  dispatch({
+  	type:       'remove',
+      newSighting: { SightingObject }, // [REQUIRED] The updated object
+      updateID:    IDNum               // [REQUIRED] The id of the sighting to be updated
+  });
+  ```
+
+* **Summary:** Replaces the old sighting, targeted with `updateID` with the `newSighting`.
+

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,0 +1,88 @@
+## State
+
+State is written using React Context with Hooks. The implementation can be found in `/src/context/report-context`.
+
+
+
+### How to use:
+
+To implement state into your file, you will need to imports the following:
+
+```jsx
+import React, { useContext, useState } from 'react';
+import { ReportContext } from '/src/context/report-context';
+```
+
+Once these are imported, you can start to use the state. To use it, create the following deconstructed array:
+
+```jsx
+const [state, dispatch] = useContext(ReportContext);
+```
+
+From here, you have access to any of the items in state, which can be accessed through `state.item`. 
+
+The state also uses a reducer to manipulate state, which is also accessed through the `dispatch` function. For more details, see the *'State Manipulation'* section.
+
+
+
+### Items in State:
+
+* ###### `Sightings` -- the sighting objects used and created throughout the app
+  * `id` -- unique ID of the sighting.
+  * `image` -- the image associated with each sighting
+  * `name` -- the name of the animal/sighting
+  * `date` -- date of the sighting (change to ISO-8601)
+  * `synced` -- if the sighting has been synced with the server
+  * `inProgress` -- if the sighting is currently being uploaded to the server
+
+
+
+### State Manipulation
+
+To manipulate sightings, the reducer needs to be called through the dispatcher. The dispatcher requires a single object argument, with a required field of type, and other optional fields. The valid types and their corresponding data requirements are as follows:  
+
+* ###### add
+
+  * **Usage:**
+
+    ```jsx
+    dispatch({ 
+        type:       'add', 
+        newSighting: { SightingObject }
+    });
+    ```
+
+  * **Summary:** Simply pushes the Sighting in `newSighting` to the `sightings` array.
+
+    
+
+* ###### remove
+
+  * **Usage:**
+
+    ```jsx
+    dispatch({
+    	type:    'remove',
+        removeID: IDNum
+    });
+    ```
+
+  * **Summary:** Removes the sighting with the target `removeID` from the `sightings` array.
+
+  
+
+* ###### update
+
+  * **Usage:**
+
+    ```jsx
+    dispatch({
+    	type:       'remove',
+        newSighting: { SightingObject }, // [REQUIRED] The updated object
+        updateID:    IDNum               // [REQUIRED] The id of the sighting to be updated
+    });
+    ```
+
+  * **Summary:** Replaces the old sighting, targeted with `updateID` with the `newSighting`.
+
+  

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,10 +1,10 @@
-## State
+# State
 
 State is written using React Context with Hooks. The implementation can be found in `/src/context/report-context`.
 
 
 
-### How to use:
+## How to use:
 
 To implement state into your file, you will need to imports the following:
 
@@ -25,23 +25,24 @@ The state also uses a reducer to manipulate state, which is also accessed throug
 
 
 
-### Items in State:
+## Items in State:
 
-* ###### `Sightings` -- the sighting objects used and created throughout the app
-  * `id` -- unique ID of the sighting.
-  * `image` -- the image associated with each sighting
-  * `name` -- the name of the animal/sighting
-  * `date` -- date of the sighting (change to ISO-8601)
-  * `synced` -- if the sighting has been synced with the server
-  * `inProgress` -- if the sighting is currently being uploaded to the server
+#### `Sightings` -- the sighting objects used and created throughout the app
+
+* `id` -- unique ID of the sighting.
+* `image` -- the image associated with each sighting
+* `name` -- the name of the animal/sighting
+* `date` -- date of the sighting (change to ISO-8601)
+* `synced` -- if the sighting has been synced with the server
+* `inProgress` -- if the sighting is currently being uploaded to the server
 
 
 
-### State Manipulation
+## State Manipulation
 
 To manipulate sightings, the reducer needs to be called through the dispatcher. The dispatcher requires a single object argument, with a required field of type, and other optional fields. The valid types and their corresponding data requirements are as follows:  
 
-#### **Add**
+### **add**
 
 * **Usage:**
 
@@ -56,7 +57,7 @@ To manipulate sightings, the reducer needs to be called through the dispatcher. 
 
   
 
-#### **remove**
+### **remove**
 
 * **Usage:**
 
@@ -71,7 +72,7 @@ To manipulate sightings, the reducer needs to be called through the dispatcher. 
 
 
 
-#### **update**
+### **update**
 
 * **Usage:**
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,10 +1,10 @@
-## State
+# State
 
 State is written using React Context with Hooks. The implementation can be found in `/src/context/report-context`.
 
 
 
-### How to use:
+## How to use:
 
 To implement state into your file, you will need to imports the following:
 
@@ -25,9 +25,9 @@ The state also uses a reducer to manipulate state, which is also accessed throug
 
 
 
-### Items in State:
+## Items in State:
 
-* ###### `Sightings` -- the sighting objects used and created throughout the app
+* ##### `Sightings` -- the sighting objects used and created throughout the app
   * `id` -- unique ID of the sighting.
   * `image` -- the image associated with each sighting
   * `name` -- the name of the animal/sighting
@@ -37,12 +37,11 @@ The state also uses a reducer to manipulate state, which is also accessed throug
 
 
 
-### State Manipulation
+## State Manipulation
 
 To manipulate sightings, the reducer needs to be called through the dispatcher. The dispatcher requires a single object argument, with a required field of type, and other optional fields. The valid types and their corresponding data requirements are as follows:  
 
-* ###### add
-
+* ##### Add
   * **Usage:**
 
     ```jsx
@@ -56,7 +55,7 @@ To manipulate sightings, the reducer needs to be called through the dispatcher. 
 
     
 
-* ###### remove
+* ##### Remove
 
   * **Usage:**
 
@@ -71,7 +70,7 @@ To manipulate sightings, the reducer needs to be called through the dispatcher. 
 
   
 
-* ###### update
+* ##### update
 
   * **Usage:**
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,10 +1,10 @@
-# State
+## State
 
 State is written using React Context with Hooks. The implementation can be found in `/src/context/report-context`.
 
 
 
-## How to use:
+### How to use:
 
 To implement state into your file, you will need to imports the following:
 
@@ -25,9 +25,9 @@ The state also uses a reducer to manipulate state, which is also accessed throug
 
 
 
-## Items in State:
+### Items in State:
 
-* ##### `Sightings` -- the sighting objects used and created throughout the app
+* ###### `Sightings` -- the sighting objects used and created throughout the app
   * `id` -- unique ID of the sighting.
   * `image` -- the image associated with each sighting
   * `name` -- the name of the animal/sighting
@@ -37,11 +37,12 @@ The state also uses a reducer to manipulate state, which is also accessed throug
 
 
 
-## State Manipulation
+### State Manipulation
 
 To manipulate sightings, the reducer needs to be called through the dispatcher. The dispatcher requires a single object argument, with a required field of type, and other optional fields. The valid types and their corresponding data requirements are as follows:  
 
-* ##### Add
+* **Add**
+
   * **Usage:**
 
     ```jsx
@@ -55,7 +56,7 @@ To manipulate sightings, the reducer needs to be called through the dispatcher. 
 
     
 
-* ##### Remove
+* **remove**
 
   * **Usage:**
 
@@ -70,7 +71,7 @@ To manipulate sightings, the reducer needs to be called through the dispatcher. 
 
   
 
-* ##### update
+* **update**
 
   * **Usage:**
 


### PR DESCRIPTION
Purpose: add documentation for state. 

To view the file in all its appropriate glory: https://github.com/WildbookOrg/report-app/blob/context-state-documentation/docs/state.md

NOTE: This should be merged after the #27 is merged into master. But as these were separate Trello tasks, I decided it might be smarter to separate them out, especially as I want 27 merged ASAP and this can wait for more revisions, as the documentation is new.

Testing: None Needed.